### PR TITLE
Share Post via Twitter

### DIFF
--- a/src/components/post-footer.js
+++ b/src/components/post-footer.js
@@ -1,8 +1,17 @@
-export default function PostFooter() {
+export default function PostFooter({ url }) {
   return (
     <div className="my-8 font-medium">
-      Thanks for taking the time to read my blog post! If you would like to stay
-      up to date on my posts, feel free to subscribe to my RSS feed&nbsp;
+      Thanks for taking the time to read this blog post! <br />
+      <br />
+      If you think others would enjoy it, please share it on&nbsp;
+      <a
+        className="dark:text-white text-black underline"
+        href={`https://twitter.com/intent/tweet?url=${encodeURI(url)}`}
+      >
+        Twitter
+      </a>
+      . Interested in staying up to date on my posts as they're publised? Feel
+      free to subscribe to the RSS feed&nbsp;
       <a
         className="dark:text-white text-black underline"
         href="https://aaronbos.dev/feed.xml"

--- a/src/pages/posts/[id].js
+++ b/src/pages/posts/[id].js
@@ -26,7 +26,9 @@ export default function Post({ post }) {
         date={post.date}
       />
       <PostBody content={post.content} />
-      <PostFooter />
+      <PostFooter
+        url={`${process.env.NEXT_PUBLIC_ORIGIN}/posts/${post.slug}`}
+      />
       <AllPostsLink text="See More Posts" />
     </Layout>
   );

--- a/src/pages/posts/[id].js
+++ b/src/pages/posts/[id].js
@@ -8,6 +8,10 @@ import Head from "next/head";
 import AllPostsLink from "../../components/all-posts-link";
 import MetaSocial from "../../components/meta-social";
 
+function getPostUrl(slug) {
+  return `${process.env.NEXT_PUBLIC_ORIGIN}/posts/${slug}`;
+}
+
 export default function Post({ post }) {
   return (
     <Layout>
@@ -16,7 +20,7 @@ export default function Post({ post }) {
       </Head>
       <MetaSocial
         title={post.title}
-        url={`${process.env.NEXT_PUBLIC_ORIGIN}/posts/${post.slug}`}
+        url={getPostUrl(post.slug)}
         description={post.description}
         image={`${process.env.NEXT_PUBLIC_ORIGIN}/static/card-logo.png`}
       />
@@ -26,9 +30,7 @@ export default function Post({ post }) {
         date={post.date}
       />
       <PostBody content={post.content} />
-      <PostFooter
-        url={`${process.env.NEXT_PUBLIC_ORIGIN}/posts/${post.slug}`}
-      />
+      <PostFooter url={getPostUrl(post.slug)} />
       <AllPostsLink text="See More Posts" />
     </Layout>
   );


### PR DESCRIPTION
## Purpose

In order to make it easier for readers to share posts on Twitter, create a link that will take them to Twitter and populate a new tweet with relevant information.

## Change Summary

Add a new section to the existing `PostFooter` component with a link to Twitter
Pass to the post URL to the `PostFooter` component
URI encode the post URL

## Considerations

Had a few options for linking out to Twitter. I decided to go with a simple [Web Intent](https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/guides/web-intent) anchor tag because it's simple to implement and very lightweight (compared to linking out to Twitter and pulling in their JavaScript to create a tweet). 

Ultimately decided to just put the post URL in the web intent to be auto-filled when composing the Tweet. I felt that including any extra text would either be (1) corny or (2) changed by the composer anyway.