### PR TITLE
Add "search by tag" functionality for tag pills

### DIFF
--- a/components/post-footer.tsx
+++ b/components/post-footer.tsx
@@ -1,6 +1,6 @@
 export default function PostFooter() {
   return (
-    <div className="my-6 font-medium">
+    <div className="my-5 font-medium">
       As always thank you for taking the time to read this blog post!
     </div>
   );

--- a/components/reaction-row.tsx
+++ b/components/reaction-row.tsx
@@ -73,7 +73,7 @@ export default function ReactionRow({ postSlug, url }: Props) {
   return (
     <>
       <hr className="mt-6" />
-      <div className="my-3 pt-2 flex flex-wrap">
+      <div className="my-2 pt-2 flex flex-wrap">
         {!error && (
           <button
             type="button"

--- a/components/tag.tsx
+++ b/components/tag.tsx
@@ -7,7 +7,7 @@ interface Props {
 export default function Tag({ tag }: Props) {
   return (
     <Link
-      href={`/search?q=${encodeURIComponent(`${tag}`)}&a=metadata`}
+      href={`/search?q=${encodeURIComponent(`tag:${tag}`)}`}
       className="inline-block my-1 mr-1 py-1.5 px-2 rounded-md text-white dark:bg-neutral-900 bg-blue-800 text-sm
       hover:ring-2 dark:hover:bg-stone-900 dark:hover:text-blue-100 ring-stone-400"
     >

--- a/components/tag.tsx
+++ b/components/tag.tsx
@@ -8,8 +8,8 @@ export default function Tag({ tag }: Props) {
   return (
     <Link
       href={`/search?q=${encodeURIComponent(`tag:${tag}`)}`}
-      className="inline-block my-1 mr-1 py-1.5 px-2 rounded-md text-white dark:bg-neutral-900 bg-blue-800 text-sm
-      hover:ring-2 dark:hover:bg-stone-900 dark:hover:text-blue-100 ring-stone-400"
+      className="inline-block my-1 mr-1 py-1.5 px-2 rounded-md text-white dark:bg-stone-900 bg-blue-500 hover:bg-blue-700 text-sm
+      dark:hover:ring-2 dark:hover:bg-stone-900 dark:hover:text-blue-100 dark:ring-stone-400"
     >
       {`#${tag}`}
     </Link>

--- a/components/tag.tsx
+++ b/components/tag.tsx
@@ -1,11 +1,17 @@
+import Link from "next/link";
+
 interface Props {
   tag: string;
 }
 
 export default function Tag({ tag }: Props) {
   return (
-    <div className="inline-block my-1 mr-1 py-1.5 px-2 rounded-md text-white dark:bg-neutral-900 bg-blue-800 text-sm">
+    <Link
+      href={`/search?q=${encodeURIComponent(`${tag}`)}&a=metadata`}
+      className="inline-block my-1 mr-1 py-1.5 px-2 rounded-md text-white dark:bg-neutral-900 bg-blue-800 text-sm
+      hover:ring-2 dark:hover:bg-stone-900 dark:hover:text-blue-100 ring-stone-400"
+    >
       {`#${tag}`}
-    </div>
+    </Link>
   );
 }

--- a/lib/request-handlers/search-request.ts
+++ b/lib/request-handlers/search-request.ts
@@ -9,7 +9,6 @@ export async function handleGet(
   query: string
 ): Promise<ApiResponse<SearchHit[]>> {
   const rawResults = await search(parseQuery(query));
-  console.log(rawResults);
 
   return {
     // Unfortunately need to map here to make sure the entire content isn't sent in the response
@@ -34,17 +33,15 @@ type AlgoliaQuery = {
 };
 
 function parseQuery(query: string): AlgoliaQuery {
-  console.log(query);
   // Currently this only supports a single tag, but could be expanded if needed
   if (query.toLowerCase().startsWith("tag:")) {
-    return { query: "", filters: `metadata:"${query.substring(4)}"` };
+    return { query: "", filters: `metadata:${query.substring(4)}` };
   }
 
   return { query };
 }
 
 async function search(query: AlgoliaQuery) {
-  console.log(query);
   const client = algoliasearch(
     process.env.ALGOLIA_APP_ID!,
     process.env.ALGOLIA_SEARCH_API_KEY!
@@ -55,6 +52,5 @@ async function search(query: AlgoliaQuery) {
     return (await index.search<SearchHit>(query.query)).hits;
   }
 
-  return (await index.search<SearchHit>("", { filters: 'metadata: "musings"' }))
-    .hits;
+  return (await index.search<SearchHit>("", { filters: query.filters })).hits;
 }

--- a/lib/request-handlers/search-request.ts
+++ b/lib/request-handlers/search-request.ts
@@ -1,7 +1,4 @@
-import algoliasearch, {
-  AlgoliaSearchOptions,
-  SearchIndex,
-} from "algoliasearch";
+import algoliasearch from "algoliasearch";
 import { BlogIndex } from "../../constants";
 import { ApiResponse, SearchHit } from "../../types/api/types";
 

--- a/lib/request-handlers/search-request.ts
+++ b/lib/request-handlers/search-request.ts
@@ -9,22 +9,16 @@ export async function handleGet(
 
   return {
     // Unfortunately need to map here to make sure the entire content isn't sent in the response
-    data: rawResults
-      .map((h) => {
-        return {
-          objectID: h.objectID,
-          title: h.title,
-          description: h.description,
-          date: h.date,
-          metadata: h.metadata,
-          slug: h.slug,
-        };
-      })
-      .sort(
-        (a, b) =>
-          new Date(b.date).getMilliseconds() -
-          new Date(a.date).getMilliseconds()
-      ),
+    data: rawResults.map((h) => {
+      return {
+        objectID: h.objectID,
+        title: h.title,
+        description: h.description,
+        date: h.date,
+        metadata: h.metadata,
+        slug: h.slug,
+      };
+    }),
     isSuccess: true,
     message: "",
   };

--- a/lib/request-handlers/search-request.ts
+++ b/lib/request-handlers/search-request.ts
@@ -1,26 +1,16 @@
-import algoliasearch from "algoliasearch";
+import algoliasearch, {
+  AlgoliaSearchOptions,
+  SearchIndex,
+} from "algoliasearch";
 import { BlogIndex } from "../../constants";
 import { ApiResponse, SearchHit } from "../../types/api/types";
 
 export async function handleGet(
-  query: string,
-  attribute?: "metadata"
+  query: string
 ): Promise<ApiResponse<SearchHit[]>> {
-  const client = algoliasearch(
-    process.env.ALGOLIA_APP_ID!,
-    process.env.ALGOLIA_SEARCH_API_KEY!
-  );
+  const rawResults = await search(parseQuery(query));
+  console.log(rawResults);
 
-  const index = client.initIndex(BlogIndex);
-  let algoliaResults;
-  if (!attribute) {
-    algoliaResults = (await index.search<SearchHit>(query)).hits;
-  } else {
-    algoliaResults = (
-      await index.search<SearchHit>("", { filters: `${attribute}:${query}` })
-    ).hits;
-  }
-  const rawResults = (await index.search<SearchHit>(query)).hits;
   return {
     // Unfortunately need to map here to make sure the entire content isn't sent in the response
     data: rawResults.map((h) => {
@@ -36,4 +26,35 @@ export async function handleGet(
     isSuccess: true,
     message: "",
   };
+}
+
+type AlgoliaQuery = {
+  query: string;
+  filters?: string;
+};
+
+function parseQuery(query: string): AlgoliaQuery {
+  console.log(query);
+  // Currently this only supports a single tag, but could be expanded if needed
+  if (query.toLowerCase().startsWith("tag:")) {
+    return { query: "", filters: `metadata:"${query.substring(4)}"` };
+  }
+
+  return { query };
+}
+
+async function search(query: AlgoliaQuery) {
+  console.log(query);
+  const client = algoliasearch(
+    process.env.ALGOLIA_APP_ID!,
+    process.env.ALGOLIA_SEARCH_API_KEY!
+  );
+
+  const index = client.initIndex(BlogIndex);
+  if (!query.filters) {
+    return (await index.search<SearchHit>(query.query)).hits;
+  }
+
+  return (await index.search<SearchHit>("", { filters: 'metadata: "musings"' }))
+    .hits;
 }

--- a/lib/request-handlers/search-request.ts
+++ b/lib/request-handlers/search-request.ts
@@ -9,16 +9,22 @@ export async function handleGet(
 
   return {
     // Unfortunately need to map here to make sure the entire content isn't sent in the response
-    data: rawResults.map((h) => {
-      return {
-        objectID: h.objectID,
-        title: h.title,
-        description: h.description,
-        date: h.date,
-        metadata: h.metadata,
-        slug: h.slug,
-      };
-    }),
+    data: rawResults
+      .map((h) => {
+        return {
+          objectID: h.objectID,
+          title: h.title,
+          description: h.description,
+          date: h.date,
+          metadata: h.metadata,
+          slug: h.slug,
+        };
+      })
+      .sort(
+        (a, b) =>
+          new Date(b.date).getMilliseconds() -
+          new Date(a.date).getMilliseconds()
+      ),
     isSuccess: true,
     message: "",
   };

--- a/lib/request-handlers/search-request.ts
+++ b/lib/request-handlers/search-request.ts
@@ -3,7 +3,8 @@ import { BlogIndex } from "../../constants";
 import { ApiResponse, SearchHit } from "../../types/api/types";
 
 export async function handleGet(
-  query: string
+  query: string,
+  attribute?: "metadata"
 ): Promise<ApiResponse<SearchHit[]>> {
   const client = algoliasearch(
     process.env.ALGOLIA_APP_ID!,
@@ -11,6 +12,14 @@ export async function handleGet(
   );
 
   const index = client.initIndex(BlogIndex);
+  let algoliaResults;
+  if (!attribute) {
+    algoliaResults = (await index.search<SearchHit>(query)).hits;
+  } else {
+    algoliaResults = (
+      await index.search<SearchHit>("", { filters: `${attribute}:${query}` })
+    ).hits;
+  }
   const rawResults = (await index.search<SearchHit>(query)).hits;
   return {
     // Unfortunately need to map here to make sure the entire content isn't sent in the response

--- a/pages/api/post/search.ts
+++ b/pages/api/post/search.ts
@@ -22,9 +22,8 @@ export default async function handler(
 
 interface Params {
   query: string;
-  attribute?: "metadata";
 }
 
 function parseRequestBody(body: any): Params {
-  return { query: body["query"], attribute: body["attribute"] };
+  return { query: body["query"] };
 }

--- a/pages/api/post/search.ts
+++ b/pages/api/post/search.ts
@@ -22,8 +22,9 @@ export default async function handler(
 
 interface Params {
   query: string;
+  attribute?: "metadata";
 }
 
 function parseRequestBody(body: any): Params {
-  return { query: body["query"] };
+  return { query: body["query"], attribute: body["attribute"] };
 }

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -9,6 +9,7 @@ import AllPostsLink from "../../components/all-posts-link";
 import MetaSocial from "../../components/meta-social";
 import { GetStaticProps } from "next";
 import ReactionRow from "../../components/reaction-row";
+import TagHolder from "../../components/tag-holder";
 
 interface Props {
   post: BlogPost;
@@ -37,6 +38,7 @@ export default function Post({ post }: Props) {
       />
       <PostBody content={post.content} />
       <ReactionRow postSlug={post.slug} url={getPostUrl(post.slug)} />
+      <TagHolder tags={post.metadata} />
       <PostFooter />
       <AllPostsLink text="See More Posts" />
     </Layout>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -77,7 +77,7 @@ export default function Search() {
               placeholder="Search posts"
               maxLength={MaxSearchLength}
               id="q"
-              defaultValue={decodedQuery}
+              defaultValue={q && decodedQuery}
               className="my-5 mx-auto w-1/2 flex-1 sm:w-3/4 dark:focus:ring-stone-400 dark:focus:ring-2 dark:focus:border-0 dark:bg-stone-800 dark:text-white rounded-md"
               type="search"
               onKeyUp={(e) => {

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -11,6 +11,7 @@ import { ApiResponse, SearchHit } from "../types/api/types";
 export default function Search() {
   const router = useRouter();
   const q = router.query["q"] as string | undefined;
+  const attr = router.query["a"] as string | undefined;
   const decodedQuery = decodeURIComponent(q ?? "");
   const [results, setResults] = useState<Array<SearchHit>>([]);
   const [searchError, setSearchError] = useState<string>("");
@@ -26,6 +27,7 @@ export default function Search() {
           method: "POST",
           body: JSON.stringify({
             query: query,
+            attribute: attr,
           }),
           headers: new Headers({
             "Content-Type": "application/json",

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -11,7 +11,6 @@ import { ApiResponse, SearchHit } from "../types/api/types";
 export default function Search() {
   const router = useRouter();
   const q = router.query["q"] as string | undefined;
-  const attr = router.query["a"] as string | undefined;
   const decodedQuery = decodeURIComponent(q ?? "");
   const [results, setResults] = useState<Array<SearchHit>>([]);
   const [searchError, setSearchError] = useState<string>("");
@@ -27,7 +26,6 @@ export default function Search() {
           method: "POST",
           body: JSON.stringify({
             query: query,
-            attribute: attr,
           }),
           headers: new Headers({
             "Content-Type": "application/json",

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -12,6 +12,7 @@ export default function Search() {
   const router = useRouter();
   const q = router.query["q"] as string | undefined;
   const decodedQuery = decodeURIComponent(q ?? "");
+  const [input, setInput] = useState(decodedQuery ?? "");
   const [results, setResults] = useState<Array<SearchHit>>([]);
   const [searchError, setSearchError] = useState<string>("");
 
@@ -41,6 +42,7 @@ export default function Search() {
         }
       };
 
+      setInput(decodedQuery);
       search(sanitizedQuery);
     }
   }, [q]);
@@ -48,7 +50,7 @@ export default function Search() {
   const handleClick = () => handleSearch();
 
   const handleSearch = () => {
-    const query = (document.getElementById("q") as HTMLInputElement).value;
+    let query = (document.getElementById("q") as HTMLInputElement).value;
     if ((query && query.length === 0) || typeof query !== "string") {
       return;
     }
@@ -77,7 +79,8 @@ export default function Search() {
               placeholder="Search posts"
               maxLength={MaxSearchLength}
               id="q"
-              defaultValue={q && decodedQuery}
+              onChange={(e) => setInput(e.target.value)}
+              value={input}
               className="my-5 mx-auto w-1/2 flex-1 sm:w-3/4 dark:focus:ring-stone-400 dark:focus:ring-2 dark:focus:border-0 dark:bg-stone-800 dark:text-white rounded-md"
               type="search"
               onKeyUp={(e) => {

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -50,15 +50,14 @@ export default function Search() {
   const handleClick = () => handleSearch();
 
   const handleSearch = () => {
-    let query = (document.getElementById("q") as HTMLInputElement).value;
-    if ((query && query.length === 0) || typeof query !== "string") {
+    if (input && input.length === 0) {
       return;
     }
 
     router.push({
       pathname: "/search",
       query: {
-        q: encodeURIComponent(query.trim()),
+        q: encodeURIComponent(input.trim()),
       },
     });
   };


### PR DESCRIPTION
## Overview

In order to make similar blogs more discoverable, readers will now be able to click on the post tags from the post preview and posts page.

When the tag is clicked the user will be routed to the search page and the search query with formatted `"tag:<tag>"`. The API will parse this query and make a specific request to Algolia to return only results with that tag. This required a change to the index configuration to make the tag field searchable.