### PR TITLE
Posts Pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 | Q1      | Framework and dependency upgrades             | Done ([PR](https://github.com/aaronmbos/personal-site/pull/24))                                                                                                                                                                           |
 | Q2      | Migrate posts from markdown files to database | Done ([PR](https://github.com/aaronmbos/personal-site/pull/33))                                                                                                                                                                           |
 | Q3      | Improve post search experience                | Done ([1](https://github.com/aaronmbos/personal-site/pull/40), [2](https://github.com/aaronmbos/personal-site/pull/42), [3](https://github.com/aaronmbos/personal-site/pull/43), [4](https://github.com/aaronmbos/personal-site/pull/46)) |
-| Q4      | Add pagination to posts page                  | In progress ([Branch](https://github.com/aaronmbos/personal-site/tree/feat/q4-post-pagination))                                                                                                                                           |
+| Q4      | Add pagination to posts page                  | Done ([PR](https://github.com/aaronmbos/personal-site/pull/51))                                                                                                                                                                           |
 
 ### 2022
 

--- a/components/pagination-row.tsx
+++ b/components/pagination-row.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default function PaginationRow({ page, limit }: Props) {
   return (
-    <div className="flex justify-evenly py-1">
+    <div className="flex justify-evenly pt-4">
       {page > 1 && (
         <button
           className="mr-auto ml-2 hover:ring-2 ring-stone-400 dark:bg-stone-800 dark:hover:bg-stone-900 text-blue-500 hover:text-blue-700 dark:text-blue-300 dark:hover:text-blue-100 px-3 py-2 rounded-md text-sm font-medium"

--- a/components/pagination-row.tsx
+++ b/components/pagination-row.tsx
@@ -1,0 +1,39 @@
+import router from "next/router";
+
+interface Props {
+  page: number;
+  limit: number;
+}
+
+export default function PaginationRow({ page, limit }: Props) {
+  return (
+    <div className="flex justify-evenly py-1">
+      {page > 1 && (
+        <button
+          className="mr-auto ml-2 hover:ring-2 ring-stone-400 dark:bg-stone-800 dark:hover:bg-stone-900 text-blue-500 hover:text-blue-700 dark:text-blue-300 dark:hover:text-blue-100 px-3 py-2 rounded-md text-sm font-medium"
+          onClick={() => {
+            router.push({
+              pathname: "/posts",
+              query: { page: page - 1 },
+            });
+          }}
+        >
+          ← Previous
+        </button>
+      )}
+      {page < limit && (
+        <button
+          className="ml-auto mr-2 hover:ring-2 ring-stone-400 dark:bg-stone-800 dark:hover:bg-stone-900 text-blue-500 hover:text-blue-700 dark:text-blue-300 dark:hover:text-blue-100 px-3 py-2 rounded-md text-sm font-medium"
+          onClick={() => {
+            router.push({
+              pathname: "/posts",
+              query: { page: page + 1 },
+            });
+          }}
+        >
+          Next →
+        </button>
+      )}
+    </div>
+  );
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -43,7 +43,7 @@ export async function getPaginatedPosts(
 ): Promise<Paged<SlimPost>> {
   const offset = (page - 1) * pageSize;
   const posts = await sql<
-    Omit<PagedPost, "content">[]
+    PagedPost[]
   >`select id, title, slug, description, tags, (published_at at time zone 'utc') as published_at, count from post.post
     cross join (select count(*) from post.post where published_at is not null) as count
     where published_at is not null

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -37,7 +37,17 @@ export async function getPostByUrlId(urlId: string): Promise<BlogPost | never> {
   return toBlogPost(post);
 }
 
-export async function getPaginatedPosts(page: number, pageSize: number) {}
+export async function getPaginatedPosts(
+  page: number,
+  pageSize: number
+): Promise<BlogPost[]> {
+  const offset = page * pageSize;
+  const posts = await sql<
+    Post[]
+  >`${baseQuery} order by published_at desc limit ${pageSize} offset ${offset}`;
+
+  return posts.map(toBlogPost);
+}
 
 function formatDate(date: Date): string {
   var options: Intl.DateTimeFormatOptions = {

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -82,7 +82,7 @@ function toBlogPost(post: Post): BlogPost {
   };
 }
 
-function toPostPreview(post: Omit<PagedPost, "content">): SlimPost {
+function toPostPreview(post: PagedPost): SlimPost {
   return {
     id: post.id,
     title: post.title as string,

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,4 +1,3 @@
-import postgres from "postgres";
 import sql from "../database/db.mjs";
 import { PagedPost, Post } from "../types/database/types.js";
 import { Paged, SlimPost } from "../types/api/types.js";

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -41,7 +41,7 @@ export async function getPaginatedPosts(
   page: number,
   pageSize: number
 ): Promise<BlogPost[]> {
-  const offset = page * pageSize;
+  const offset = (page - 1) * pageSize;
   const posts = await sql<
     Post[]
   >`${baseQuery} order by published_at desc limit ${pageSize} offset ${offset}`;

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -37,6 +37,8 @@ export async function getPostByUrlId(urlId: string): Promise<BlogPost | never> {
   return toBlogPost(post);
 }
 
+export async function getPaginatedPosts(page: number, pageSize: number) {}
+
 function formatDate(date: Date): string {
   var options: Intl.DateTimeFormatOptions = {
     weekday: "long",

--- a/pages/api/post/page/[page].ts
+++ b/pages/api/post/page/[page].ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getPaginatedPosts } from "../../../../lib/posts";
+import { handleError } from "../../errorHandler";
 
 const defaultPageSize = 15;
 
@@ -9,19 +10,16 @@ export default async function handler(
 ) {
   try {
     const params = parseRequestParams(req);
-
     if (req.method === "GET") {
       const posts = await getPaginatedPosts(params.page, defaultPageSize);
       return res.status(200).json({ isSuccess: true, data: posts });
     }
   } catch (error) {
-    if (error instanceof Error) {
-      if (!process.env.VERCEL_ENV?.includes("production")) {
-        return res.status(500).json(error.message);
-      }
-
-      return res.status(500).json("An error occurred.");
-    }
+    handleError(
+      res,
+      error,
+      "An error occurred getting posts. Please try again later."
+    );
   }
 }
 

--- a/pages/api/post/page/[page].ts
+++ b/pages/api/post/page/[page].ts
@@ -1,0 +1,42 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getPaginatedPosts } from "../../../../lib/posts";
+
+const defaultPageSize = 15;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const params = parseRequestParams(req);
+
+    if (req.method === "GET") {
+      const posts = await getPaginatedPosts(params.page, defaultPageSize);
+      return res.status(200).json({ isSuccess: true, data: posts });
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      if (!process.env.VERCEL_ENV?.includes("production")) {
+        return res.status(500).json(error.message);
+      }
+
+      return res.status(500).json("An error occurred.");
+    }
+  }
+}
+
+interface Params {
+  page: number;
+}
+
+function parseRequestParams(req: NextApiRequest): Params {
+  const { page } = req.query;
+
+  if (!page || typeof page !== "string") {
+    return { page: 1 };
+  }
+
+  return {
+    page: parseInt(page),
+  };
+}

--- a/pages/posts.tsx
+++ b/pages/posts.tsx
@@ -2,15 +2,17 @@ import Layout from "../components/layout";
 import PostPreview from "../components/post-preview";
 import { getPaginatedPosts, BlogPost } from "../lib/posts";
 import Head from "next/head";
-import { GetServerSideProps } from "next";
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import { useRouter } from "next/router";
+import PaginationRow from "../components/pagination-row";
 
 interface Props {
   posts: BlogPost[];
   page: number;
+  limit: number;
 }
 
-export default function Posts({ posts, page }: Props) {
+export default function Posts({ posts, page, limit }: Props) {
   const router = useRouter();
 
   return (
@@ -26,39 +28,19 @@ export default function Posts({ posts, page }: Props) {
             return <PostPreview key={post.id} {...post} />;
           })}
         </section>
-        {/* TODO: Add paging component */}
-        <button
-          onClick={() => {
-            router.push({
-              pathname: "/posts",
-              query: { page: page + 1 },
-            });
-          }}
-        >
-          Forward
-        </button>
-        <button
-          onClick={() => {
-            router.push({
-              pathname: "/posts",
-              query: { page: page - 1 },
-            });
-          }}
-        >
-          Back
-        </button>
+        <PaginationRow page={page} limit={limit} />
       </Layout>
     </>
   );
 }
-
-export const getServerSideProps = (async ({ res, query }) => {
-  const page = parseInt(query["page"] as string) || 1;
-  const posts = await getPaginatedPosts(page, 15);
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const page = parseInt(context.query["page"] as string) || 1;
+  const { data, limit } = await getPaginatedPosts(page, 15);
   return {
     props: {
-      posts,
+      posts: data,
       page,
+      limit,
     },
   };
-}) satisfies GetServerSideProps<Props>;
+}

--- a/pages/posts.tsx
+++ b/pages/posts.tsx
@@ -1,16 +1,17 @@
 import Layout from "../components/layout";
 import PostPreview from "../components/post-preview";
-import { getAllPosts, getPaginatedPosts, BlogPost } from "../lib/posts";
+import { getPaginatedPosts, BlogPost } from "../lib/posts";
 import Head from "next/head";
-import { GetStaticProps } from "next";
-import { useState } from "react";
+import { GetServerSideProps } from "next";
+import { useRouter } from "next/router";
 
 interface Props {
   posts: BlogPost[];
+  page: number;
 }
 
-export default function Posts({ posts }: Props) {
-  const [page, setPage] = useState(1);
+export default function Posts({ posts, page }: Props) {
+  const router = useRouter();
 
   return (
     <>
@@ -28,14 +29,20 @@ export default function Posts({ posts }: Props) {
         {/* TODO: Add paging component */}
         <button
           onClick={() => {
-            setPage(page + 1);
+            router.push({
+              pathname: "/posts",
+              query: { page: page + 1 },
+            });
           }}
         >
           Forward
         </button>
         <button
           onClick={() => {
-            setPage(page - 1);
+            router.push({
+              pathname: "/posts",
+              query: { page: page - 1 },
+            });
           }}
         >
           Back
@@ -45,11 +52,13 @@ export default function Posts({ posts }: Props) {
   );
 }
 
-export const getStaticProps: GetStaticProps = async () => {
-  const posts = await getPaginatedPosts(1, 15);
+export const getServerSideProps = (async ({ res, query }) => {
+  const page = parseInt(query["page"] as string) || 1;
+  const posts = await getPaginatedPosts(page, 15);
   return {
     props: {
       posts,
+      page,
     },
   };
-};
+}) satisfies GetServerSideProps<Props>;

--- a/pages/posts.tsx
+++ b/pages/posts.tsx
@@ -1,37 +1,33 @@
 import Layout from "../components/layout";
 import PostPreview from "../components/post-preview";
-import { getPaginatedPosts, BlogPost } from "../lib/posts";
 import Head from "next/head";
-import { GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import PaginationRow from "../components/pagination-row";
 import useSWR from "swr";
 import { ApiResponse, Paged, SlimPost } from "../types/api/types";
+import LoadingSpinner from "../components/loading-spinner";
 
-interface Props {
-  posts: BlogPost[];
-  limit: number;
-}
-
-export default function Posts({ posts, limit }: Props) {
+export default function Posts() {
   const router = useRouter();
   const pageParam = router.query.page
     ? parseInt(router.query.page as string) || 1
     : 1;
 
   const getPostsForPage = async () => {
-    if (pageParam !== 1) {
-      const response = await fetch(`/api/post/page/${pageParam}`, {
-        headers: new Headers({
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        }),
-      });
-      const results = (await response.json()) as ApiResponse<Paged<SlimPost>>;
+    const response = await fetch(`/api/post/page/${pageParam}`, {
+      headers: new Headers({
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      }),
+    });
+    const results = (await response.json()) as ApiResponse<Paged<SlimPost>>;
 
-      return results.data.data;
+    if (results?.isSuccess) {
+      return results.data;
     } else {
-      return posts;
+      throw new Error(
+        results?.message ?? "An error occurred while getting posts."
+      );
     }
   };
 
@@ -49,28 +45,27 @@ export default function Posts({ posts, limit }: Props) {
         <section className="mb-10">
           <h1 className="mb-4 font-semibold text-2xl">All Blog Posts</h1>
           <hr />
-          {isLoading && pageParam !== 1 ? (
-            <div>Loading ...</div>
+          {isLoading ? (
+            <div className="text-center font-bold my-3">
+              Loading posts
+              <LoadingSpinner />
+            </div>
+          ) : error ? (
+            <div className="text-center my-2 text-red-500 dark:text-red-300">
+              {error.message}
+            </div>
           ) : (
-            data &&
-            data.map((post) => {
-              return <PostPreview key={post.id} {...post} />;
-            })
+            data && (
+              <>
+                {data.data.map((post) => {
+                  return <PostPreview key={post.id} {...post} />;
+                })}
+                <PaginationRow page={pageParam} limit={data.limit} />
+              </>
+            )
           )}
         </section>
-        <PaginationRow page={pageParam} limit={limit} />
       </Layout>
     </>
   );
 }
-
-export const getStaticProps: GetStaticProps = async () => {
-  const { data, limit } = await getPaginatedPosts(1, 15);
-
-  return {
-    props: {
-      posts: data,
-      limit,
-    },
-  };
-};

--- a/pages/posts.tsx
+++ b/pages/posts.tsx
@@ -22,11 +22,13 @@ export default function Posts({ posts }: Props) {
             return <PostPreview key={post.id} {...post} />;
           })}
         </section>
+        {/* TODO: Add paging component */}
       </Layout>
     </>
   );
 }
 
+// TODO: Convert to getServerSideProps using paginated request
 export const getStaticProps: GetStaticProps = async () => {
   const posts = await getAllPosts();
   return {

--- a/pages/posts.tsx
+++ b/pages/posts.tsx
@@ -2,9 +2,15 @@ import Layout from "../components/layout";
 import PostPreview from "../components/post-preview";
 import { getPaginatedPosts, BlogPost } from "../lib/posts";
 import Head from "next/head";
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  GetStaticProps,
+} from "next";
 import { useRouter } from "next/router";
 import PaginationRow from "../components/pagination-row";
+import { useEffect } from "react";
+import useSWR from "swr";
 
 interface Props {
   posts: BlogPost[];
@@ -14,6 +20,20 @@ interface Props {
 
 export default function Posts({ posts, page, limit }: Props) {
   const router = useRouter();
+  const pageParam = router.query.page
+    ? parseInt(router.query.page as string) || 1
+    : 1;
+
+  const getPostsForPage = async () => {
+    if (pageParam !== 1) {
+      console.log("Fetching posts for page " + pageParam);
+    }
+  };
+
+  const { data, error, isLoading } = useSWR(
+    pageParam === 1 ? null : `/api/posts/page/${pageParam}`,
+    getPostsForPage
+  );
 
   return (
     <>
@@ -33,9 +53,11 @@ export default function Posts({ posts, page, limit }: Props) {
     </>
   );
 }
-export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const page = parseInt(context.query["page"] as string) || 1;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const page = 1;
   const { data, limit } = await getPaginatedPosts(page, 15);
+
   return {
     props: {
       posts: data,
@@ -43,4 +65,16 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       limit,
     },
   };
-}
+};
+
+//export async function getServerSideProps(context: GetServerSidePropsContext) {
+//  const page = parseInt(context.query["page"] as string) || 1;
+//  const { data, limit } = await getPaginatedPosts(page, 15);
+//  return {
+//    props: {
+//      posts: data,
+//      page,
+//      limit,
+//    },
+//  };
+//}

--- a/pages/posts.tsx
+++ b/pages/posts.tsx
@@ -1,14 +1,17 @@
 import Layout from "../components/layout";
 import PostPreview from "../components/post-preview";
-import { getAllPosts, BlogPost } from "../lib/posts";
+import { getAllPosts, getPaginatedPosts, BlogPost } from "../lib/posts";
 import Head from "next/head";
 import { GetStaticProps } from "next";
+import { useState } from "react";
 
 interface Props {
   posts: BlogPost[];
 }
 
 export default function Posts({ posts }: Props) {
+  const [page, setPage] = useState(1);
+
   return (
     <>
       <Head>
@@ -23,14 +26,27 @@ export default function Posts({ posts }: Props) {
           })}
         </section>
         {/* TODO: Add paging component */}
+        <button
+          onClick={() => {
+            setPage(page + 1);
+          }}
+        >
+          Forward
+        </button>
+        <button
+          onClick={() => {
+            setPage(page - 1);
+          }}
+        >
+          Back
+        </button>
       </Layout>
     </>
   );
 }
 
-// TODO: Convert to getServerSideProps using paginated request
 export const getStaticProps: GetStaticProps = async () => {
-  const posts = await getAllPosts();
+  const posts = await getPaginatedPosts(1, 15);
   return {
     props: {
       posts,

--- a/types/api/types.ts
+++ b/types/api/types.ts
@@ -55,3 +55,10 @@ export type PostPatchFields =
   | "publishedAt";
 
 export const parseJsonRequest = <T>(req: string): T => JSON.parse(req) as T;
+
+export interface Paged<T> {
+  data: T[];
+  page: number;
+  limit: number;
+  total: number;
+}

--- a/types/api/types.ts
+++ b/types/api/types.ts
@@ -1,3 +1,5 @@
+import { BlogPost } from "../../lib/posts";
+
 export type ReactionType = "like";
 
 export interface Reaction {
@@ -62,3 +64,8 @@ export interface Paged<T> {
   limit: number;
   total: number;
 }
+
+export type SlimPost = Pick<
+  BlogPost,
+  "id" | "slug" | "description" | "date" | "metadata" | "title"
+>;

--- a/types/database/types.ts
+++ b/types/database/types.ts
@@ -14,4 +14,4 @@ export interface Paged {
   count: number;
 }
 
-export interface PagedPost extends Post, Paged {}
+export type PagedPost = Omit<Post & Paged, "content">;

--- a/types/database/types.ts
+++ b/types/database/types.ts
@@ -9,3 +9,9 @@ export interface Post {
   created_at: Date;
   updated_at: Date;
 }
+
+export interface Paged {
+  count: number;
+}
+
+export interface PagedPost extends Post, Paged {}


### PR DESCRIPTION
## Overview

As the number of posts has increased over time so has the size of the `/posts` page. During deployment builds I started to see this warning.

```
Warning: data for page "/posts" is 585 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance.
```

While the route loads fine in most cases, I understand that sending that data amount of data can have a larger impact on users with poor network connections. For that reason, I wanted to move away from statically generating the `/posts` page.

This PR updates the `/posts` page to use client-side rendering and pagination to hydrate the page. During development, I also tried out server-side rendering, but I prefer to have most of the page load immediately and simply wait for the request to populate the posts section.